### PR TITLE
test bump

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: d1d51bc5792c5b54659a8b09c8c300cc1c75c3060a928027d8e797aa699217e7
 
 build:
-  number: 0
+  number: 1
   script_env:
     - siriusDistName={{ siriusDistDir }}-sirius
     - siriusDistDir={{ siriusDistDir }}


### PR DESCRIPTION
`sirius --version` produced

```
Improperly specified VM option 'MaxRAMPercentage=85'
Error: Could not create the Java Virtual Machine.
```

over here https://github.com/bioconda/bioconda-recipes/pull/42392 lets check

see https://bugs.java.com/bugdatabase/view_bug?bug_id=8219312 .. should not occur in openjdk17

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
