### PR TITLE
fix missing jfx dependencies in non windows builds

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -49,7 +49,7 @@ else
     -P "build.sirius.location.lib=\$CONDA_PREFIX/share/$PKG_NAME-$PKG_VERSION-$PKG_BUILDNUM/app" \
     -P "build.sirius.starter.jdk.include=false" \
     -P "build.sirius.native.cbc.exclude=true" \
-    -P "build.sirius.native.openjfx.exclude=true" \
+    -P "build.sirius.native.openjfx.exclude=false" \
     -P "build.sirius.platform=$target_platform" \
     --stacktrace --warning-mode all
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 5d94267cde42dfc2e621299f5cbde9736f6d648328626f7cd23234e84ab514b0
 
 build:
-  number: 1
+  number: 2
   skip: True  # [ppc64le]
   script_env:
     - siriusDistName={{ siriusDistDir }}-sirius


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
